### PR TITLE
Feat: add generic type support to McpToolProvider

### DIFF
--- a/src/main/java/com/jang/mcp/starter/autoconfigure/McpAutoConfiguration.java
+++ b/src/main/java/com/jang/mcp/starter/autoconfigure/McpAutoConfiguration.java
@@ -1,5 +1,6 @@
 package com.jang.mcp.starter.autoconfigure;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jang.mcp.starter.controller.McpSseTransportFactory;
 import com.jang.mcp.starter.tool.McpToolProvider;
 import com.jang.mcp.starter.tool.builtin.ApiSpecMcpTool;
@@ -24,10 +25,12 @@ import java.util.Map;
  * Spring Boot Auto-Configuration that wires up the MCP server.
  * Collects all McpToolProvider beans, generates JSON schemas, and registers tools
  * with the MCP server via SSE transport.
+ * Uses ObjectMapper to automatically convert raw JSON arguments into typed parameter objects.
  *
  * MCP 서버를 자동 구성하는 스프링 부트 Auto-Configuration.
  * 모든 McpToolProvider 빈을 수집하고, JSON 스키마를 생성하고,
  * SSE Transport를 통해 MCP 서버에 도구를 등록한다.
+ * ObjectMapper를 사용하여 JSON 인자를 타입이 지정된 파라미터 객체로 자동 변환한다.
  */
 @AutoConfiguration
 @ConditionalOnProperty(prefix = "mcp.server", name = "enabled", havingValue = "true", matchIfMissing = true)
@@ -89,15 +92,18 @@ public class McpAutoConfiguration {
      * Creates and starts the MCP sync server.
      * Collects all McpToolProvider beans, converts their parameters to JSON Schema,
      * and registers them as MCP tools.
+     * Raw JSON arguments are automatically converted to typed objects via ObjectMapper.
      *
      * MCP 동기 서버를 생성하고 시작한다.
      * 모든 McpToolProvider 빈을 수집하고, 파라미터를 JSON Schema로 변환하여 MCP 도구로 등록한다.
+     * ObjectMapper를 통해 JSON 인자를 타입 객체로 자동 변환한다.
      */
     @Bean
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public McpSyncServer mcpSyncServer(
             HttpServletSseServerTransportProvider transportProvider,
-            List<McpToolProvider> toolProviders,
+            List<McpToolProvider<?>> toolProviders,
+            ObjectMapper objectMapper,
             McpProperties properties) {
 
         var serverSpec = McpServer.sync(transportProvider)
@@ -122,9 +128,12 @@ public class McpAutoConfiguration {
                     .inputSchema(inputSchema)
                     .build();
 
+            Class<?> paramType = provider.getParameterType();
+
             serverSpec.toolCall(tool, (exchange, request) -> {
                 try {
-                    String result = provider.execute(request.arguments());
+                    Object params = convertArguments(request.arguments(), paramType, objectMapper);
+                    String result = provider.execute(params);
                     return McpSchema.CallToolResult.builder()
                             .addTextContent(result)
                             .build();
@@ -146,5 +155,19 @@ public class McpAutoConfiguration {
                 toolProviders.size(), properties.getBaseUrl() + properties.getSseEndpoint());
 
         return server;
+    }
+
+    /**
+     * Converts raw argument map to the typed parameter object.
+     * Returns null for parameterless tools (Void type or null paramType).
+     *
+     * 원시 인자 맵을 타입이 지정된 파라미터 객체로 변환한다.
+     * 파라미터가 없는 도구(Void 또는 null)에는 null을 반환한다.
+     */
+    private Object convertArguments(Map<String, Object> arguments, Class<?> paramType, ObjectMapper objectMapper) {
+        if (paramType == null || paramType == Void.class) {
+            return null;
+        }
+        return objectMapper.convertValue(arguments, paramType);
     }
 }

--- a/src/main/java/com/jang/mcp/starter/autoconfigure/McpAutoConfiguration.java
+++ b/src/main/java/com/jang/mcp/starter/autoconfigure/McpAutoConfiguration.java
@@ -132,7 +132,17 @@ public class McpAutoConfiguration {
 
             serverSpec.toolCall(tool, (exchange, request) -> {
                 try {
-                    Object params = convertArguments(request.arguments(), paramType, objectMapper);
+                    Object params;
+                    try {
+                        params = convertArguments(request.arguments(), paramType, objectMapper);
+                    } catch (Exception e) {
+                        log.error("Argument conversion failed for tool '{}': {}", provider.getName(), e.getMessage());
+                        return McpSchema.CallToolResult.builder()
+                                .addTextContent("Error: Failed to convert arguments for tool '" + provider.getName() + "': " + e.getMessage())
+                                .isError(true)
+                                .build();
+                    }
+
                     String result = provider.execute(params);
                     return McpSchema.CallToolResult.builder()
                             .addTextContent(result)

--- a/src/main/java/com/jang/mcp/starter/autoconfigure/McpAutoConfiguration.java
+++ b/src/main/java/com/jang/mcp/starter/autoconfigure/McpAutoConfiguration.java
@@ -160,13 +160,18 @@ public class McpAutoConfiguration {
     /**
      * Converts raw argument map to the typed parameter object.
      * Returns null for parameterless tools (Void type or null paramType).
+     * Throws IllegalArgumentException if arguments are missing for a parameterized tool.
      *
      * 원시 인자 맵을 타입이 지정된 파라미터 객체로 변환한다.
      * 파라미터가 없는 도구(Void 또는 null)에는 null을 반환한다.
+     * 파라미터가 필요한 도구에 인자가 누락되면 IllegalArgumentException을 던진다.
      */
     private Object convertArguments(Map<String, Object> arguments, Class<?> paramType, ObjectMapper objectMapper) {
         if (paramType == null || paramType == Void.class) {
             return null;
+        }
+        if (arguments == null) {
+            throw new IllegalArgumentException("Missing arguments for tool that expects parameters of type " + paramType.getSimpleName());
         }
         return objectMapper.convertValue(arguments, paramType);
     }

--- a/src/main/java/com/jang/mcp/starter/tool/McpToolProvider.java
+++ b/src/main/java/com/jang/mcp/starter/tool/McpToolProvider.java
@@ -1,15 +1,19 @@
 package com.jang.mcp.starter.tool;
 
-import java.util.Map;
-
 /**
  * Common interface for defining MCP tools.
  * Spring beans implementing this interface are automatically registered to the MCP server.
+ * The type parameter T represents the tool's parameter type (use a Java Record).
+ * For tools with no parameters, use {@code Void} as the type parameter.
  *
  * MCP 도구를 정의하기 위한 공통 인터페이스.
  * 이 인터페이스를 구현한 스프링 빈은 자동으로 MCP 서버에 등록된다.
+ * 타입 파라미터 T는 도구의 파라미터 타입을 나타낸다 (Java Record 사용 권장).
+ * 파라미터가 없는 도구는 {@code Void}를 타입 파라미터로 사용한다.
+ *
+ * @param <T> the parameter type for this tool, or {@code Void} if no parameters
  */
-public interface McpToolProvider {
+public interface McpToolProvider<T> {
 
     /**
      * Unique name of the tool. MCP clients invoke the tool using this name.
@@ -27,20 +31,27 @@ public interface McpToolProvider {
 
     /**
      * Returns the Record class that defines the tool's parameters.
-     * May return null if the tool has no parameters.
+     * Returns null or Void.class if the tool has no parameters.
      * Apply @McpParameter to the Record's fields to add descriptions.
      * 
      * 도구의 파라미터를 정의하는 Record 클래스를 반환한다.
-     * 파라미터가 없으면 null을 반환할 수 있다.
+     * 파라미터가 없으면 null 또는 Void.class를 반환한다.
      * Record의 필드에 @McpParameter를 적용하여 설명을 추가한다.
      */
-    Class<?> getParameterType();
+    Class<T> getParameterType();
 
     /**
-     * Executes the tool.
+     * Executes the tool with the typed parameter object.
+     * The framework automatically converts raw JSON arguments into the specified type.
+     * For tools with no parameters (Void), this method receives null.
      *
-     * @param arguments argument map received from the MCP client
+     * 타입이 지정된 파라미터 객체를 받아 도구를 실행한다.
+     * 프레임워크가 JSON 인자를 지정된 타입으로 자동 변환한다.
+     * 파라미터가 없는 도구(Void)는 null을 받는다.
+     *
+     * @param params typed parameter object, or null for parameterless tools
      * @return result string delivered to the LLM as text
      */
-    String execute(Map<String, Object> arguments);
+    String execute(T params);
 }
+

--- a/src/main/java/com/jang/mcp/starter/tool/builtin/ApiSpecMcpTool.java
+++ b/src/main/java/com/jang/mcp/starter/tool/builtin/ApiSpecMcpTool.java
@@ -5,8 +5,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.Map;
-
 /**
  * Built-in MCP tool that fetches the OpenAPI (Swagger) specification from the host application.
  * Requires springdoc-openapi to be available in the host application.
@@ -14,7 +12,7 @@ import java.util.Map;
  * 호스트 애플리케이션에서 OpenAPI(Swagger) 스펙을 가져오는 내장 MCP 도구.
  * 호스트 앱에 springdoc-openapi가 설정되어 있어야 한다.
  */
-public class ApiSpecMcpTool implements McpToolProvider {
+public class ApiSpecMcpTool implements McpToolProvider<Void> {
 
     private static final Logger log = LoggerFactory.getLogger(ApiSpecMcpTool.class);
 
@@ -37,12 +35,12 @@ public class ApiSpecMcpTool implements McpToolProvider {
     }
 
     @Override
-    public Class<?> getParameterType() {
-        return null; // No parameters needed
+    public Class<Void> getParameterType() {
+        return null;
     }
 
     @Override
-    public String execute(Map<String, Object> arguments) {
+    public String execute(Void params) {
         try {
             String spec = restTemplate.getForObject(apiDocsUrl, String.class);
             if (spec == null || spec.isBlank()) {
@@ -55,3 +53,4 @@ public class ApiSpecMcpTool implements McpToolProvider {
         }
     }
 }
+

--- a/src/main/java/com/jang/mcp/starter/tool/builtin/BackendLogMcpTool.java
+++ b/src/main/java/com/jang/mcp/starter/tool/builtin/BackendLogMcpTool.java
@@ -11,7 +11,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Built-in MCP tool that reads the tail of the application log file.
@@ -20,7 +19,7 @@ import java.util.Map;
  * 애플리케이션 로그 파일의 마지막 N줄을 읽는 내장 MCP 도구.
  * AI 에이전트가 런타임 에러를 진단하고 애플리케이션 동작을 모니터링하는 데 유용하다.
  */
-public class BackendLogMcpTool implements McpToolProvider {
+public class BackendLogMcpTool implements McpToolProvider<BackendLogMcpTool.Params> {
 
     private static final Logger log = LoggerFactory.getLogger(BackendLogMcpTool.class);
     private static final int DEFAULT_LINES = 50;
@@ -53,19 +52,15 @@ public class BackendLogMcpTool implements McpToolProvider {
     }
 
     @Override
-    public Class<?> getParameterType() {
+    public Class<Params> getParameterType() {
         return Params.class;
     }
 
     @Override
-    public String execute(Map<String, Object> arguments) {
+    public String execute(Params params) {
         int lines = DEFAULT_LINES;
-        if (arguments != null && arguments.containsKey("lines")) {
-            try {
-                lines = ((Number) arguments.get("lines")).intValue();
-            } catch (Exception e) {
-                log.warn("Invalid 'lines' parameter, using default: {}", DEFAULT_LINES);
-            }
+        if (params != null && params.lines() != null) {
+            lines = params.lines();
         }
         lines = Math.min(Math.max(lines, 1), MAX_LINES);
 
@@ -97,4 +92,3 @@ public class BackendLogMcpTool implements McpToolProvider {
         }
     }
 }
-


### PR DESCRIPTION
## Summary

Introduces generic type parameter to `McpToolProvider<T>`, enabling type-safe tool parameter handling. Developers no longer need to manually cast from `Map<String, Object>`.

Closes #2
Closes #6 

## Changes

### `McpToolProvider<T>` interface
- `execute(Map<String, Object>)` → `execute(T params)`
- `Class<?>` → `Class<T>` for `getParameterType()`
- Parameterless tools use `Void` as type parameter

### `McpAutoConfiguration`
- Injects `ObjectMapper` to automatically convert raw JSON arguments to typed objects
- `convertArguments()` handles `null`/`Void` for parameterless tools

### Built-in tools
- `BackendLogMcpTool` → `McpToolProvider<Params>` (direct `params.lines()` access)
- `ApiSpecMcpTool` → `McpToolProvider<Void>`

## Before / After

```java
// Before 
public String execute(Map<String, Object> args) {
    String name = (String) args.get("name");  // unsafe cast
}

// After 
public String execute(Params params) {
    params.name();  // type-safe
}
