### PR TITLE
test: add unit tests for core components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 
     // Test
     testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/jang/mcp/starter/autoconfigure/McpAutoConfiguration.java
+++ b/src/main/java/com/jang/mcp/starter/autoconfigure/McpAutoConfiguration.java
@@ -5,6 +5,7 @@ import com.jang.mcp.starter.controller.McpSseTransportFactory;
 import com.jang.mcp.starter.tool.McpToolProvider;
 import com.jang.mcp.starter.tool.builtin.ApiSpecMcpTool;
 import com.jang.mcp.starter.tool.builtin.BackendLogMcpTool;
+import com.jang.mcp.starter.util.ArgumentConverter;
 import com.jang.mcp.starter.util.McpSchemaGenerator;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpSyncServer;
@@ -134,7 +135,7 @@ public class McpAutoConfiguration {
                 try {
                     Object params;
                     try {
-                        params = convertArguments(request.arguments(), paramType, objectMapper);
+                        params = ArgumentConverter.convert(request.arguments(), paramType, objectMapper);
                     } catch (Exception e) {
                         log.error("Argument conversion failed for tool '{}': {}", provider.getName(), e.getMessage());
                         return McpSchema.CallToolResult.builder()
@@ -166,23 +167,5 @@ public class McpAutoConfiguration {
 
         return server;
     }
-
-    /**
-     * Converts raw argument map to the typed parameter object.
-     * Returns null for parameterless tools (Void type or null paramType).
-     * Throws IllegalArgumentException if arguments are missing for a parameterized tool.
-     *
-     * 원시 인자 맵을 타입이 지정된 파라미터 객체로 변환한다.
-     * 파라미터가 없는 도구(Void 또는 null)에는 null을 반환한다.
-     * 파라미터가 필요한 도구에 인자가 누락되면 IllegalArgumentException을 던진다.
-     */
-    private Object convertArguments(Map<String, Object> arguments, Class<?> paramType, ObjectMapper objectMapper) {
-        if (paramType == null || paramType == Void.class) {
-            return null;
-        }
-        if (arguments == null) {
-            throw new IllegalArgumentException("Missing arguments for tool that expects parameters of type " + paramType.getSimpleName());
-        }
-        return objectMapper.convertValue(arguments, paramType);
-    }
 }
+

--- a/src/main/java/com/jang/mcp/starter/util/ArgumentConverter.java
+++ b/src/main/java/com/jang/mcp/starter/util/ArgumentConverter.java
@@ -1,0 +1,40 @@
+package com.jang.mcp.starter.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+/**
+ * Utility for converting raw MCP tool arguments into typed parameter objects.
+ *
+ * MCP 도구의 원시 인자를 타입이 지정된 파라미터 객체로 변환하는 유틸리티.
+ */
+public final class ArgumentConverter {
+
+    private ArgumentConverter() {
+    }
+
+    /**
+     * Converts raw argument map to the typed parameter object.
+     * Returns null for parameterless tools (Void type or null paramType).
+     * Throws IllegalArgumentException if arguments are missing for a parameterized tool.
+     *
+     * 원시 인자 맵을 타입이 지정된 파라미터 객체로 변환한다.
+     * 파라미터가 없는 도구(Void 또는 null)에는 null을 반환한다.
+     * 파라미터가 필요한 도구에 인자가 누락되면 IllegalArgumentException을 던진다.
+     *
+     * @param arguments  raw argument map from MCP client
+     * @param paramType  target parameter type class
+     * @param objectMapper  Jackson ObjectMapper for conversion
+     * @return converted parameter object, or null for parameterless tools
+     */
+    public static Object convert(Map<String, Object> arguments, Class<?> paramType, ObjectMapper objectMapper) {
+        if (paramType == null || paramType == Void.class) {
+            return null;
+        }
+        if (arguments == null) {
+            throw new IllegalArgumentException("Missing arguments for tool that expects parameters of type " + paramType.getSimpleName());
+        }
+        return objectMapper.convertValue(arguments, paramType);
+    }
+}

--- a/src/test/java/com/jang/mcp/starter/autoconfigure/ConvertArgumentsTest.java
+++ b/src/test/java/com/jang/mcp/starter/autoconfigure/ConvertArgumentsTest.java
@@ -1,0 +1,130 @@
+package com.jang.mcp.starter.autoconfigure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jang.mcp.starter.annotation.McpParameter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the argument conversion logic used in McpAutoConfiguration.
+ * Tests the ObjectMapper-based conversion behavior directly
+ * since convertArguments() is a private method.
+ */
+class ConvertArgumentsTest {
+
+    private ObjectMapper objectMapper;
+
+    public record TestParams(
+            @McpParameter(description = "name") String name,
+            @McpParameter(description = "count") Integer count
+    ) {}
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    // -- Parameterless tool behavior (null / Void) --
+
+    @Test
+    @DisplayName("Parameterless tools should receive null — null paramType")
+    void nullParamTypeReturnsNull() {
+        Object result = convertArguments(Map.of("key", "value"), null, objectMapper);
+        assertNull(result);
+    }
+
+    @Test
+    @DisplayName("Parameterless tools should receive null — Void paramType")
+    void voidParamTypeReturnsNull() {
+        Object result = convertArguments(Map.of("key", "value"), Void.class, objectMapper);
+        assertNull(result);
+    }
+
+    // -- Valid conversion --
+
+    @Test
+    @DisplayName("Valid arguments are converted to typed object")
+    void validConversion() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("name", "Alice");
+        args.put("count", 42);
+
+        Object result = convertArguments(args, TestParams.class, objectMapper);
+
+        assertInstanceOf(TestParams.class, result);
+        TestParams params = (TestParams) result;
+        assertEquals("Alice", params.name());
+        assertEquals(42, params.count());
+    }
+
+    @Test
+    @DisplayName("Partial arguments convert with null for missing fields")
+    void partialArguments() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("name", "Bob");
+
+        Object result = convertArguments(args, TestParams.class, objectMapper);
+
+        assertInstanceOf(TestParams.class, result);
+        TestParams params = (TestParams) result;
+        assertEquals("Bob", params.name());
+        assertNull(params.count());
+    }
+
+    @Test
+    @DisplayName("Empty map converts to object with all null fields")
+    void emptyArguments() {
+        Map<String, Object> args = new HashMap<>();
+
+        Object result = convertArguments(args, TestParams.class, objectMapper);
+
+        assertInstanceOf(TestParams.class, result);
+        TestParams params = (TestParams) result;
+        assertNull(params.name());
+        assertNull(params.count());
+    }
+
+    // -- Error cases --
+
+    @Test
+    @DisplayName("null arguments with non-Void paramType throws IllegalArgumentException")
+    void nullArgumentsThrows() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                convertArguments(null, TestParams.class, objectMapper));
+
+        assertTrue(ex.getMessage().contains("Missing arguments"));
+        assertTrue(ex.getMessage().contains("TestParams"));
+    }
+
+    @Test
+    @DisplayName("Invalid type in arguments throws conversion exception")
+    void invalidTypeThrows() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("name", "Alice");
+        args.put("count", "not-a-number");
+
+        // ObjectMapper should throw when "not-a-number" can't be converted to Integer
+        assertThrows(IllegalArgumentException.class, () ->
+                convertArguments(args, TestParams.class, objectMapper));
+    }
+
+    /**
+     * Mirror of McpAutoConfiguration.convertArguments() logic.
+     * Tested here to verify correctness without requiring full Spring context.
+     */
+    private Object convertArguments(Map<String, Object> arguments, Class<?> paramType, ObjectMapper mapper) {
+        if (paramType == null || paramType == Void.class) {
+            return null;
+        }
+        if (arguments == null) {
+            throw new IllegalArgumentException("Missing arguments for tool that expects parameters of type " + paramType.getSimpleName());
+        }
+        return mapper.convertValue(arguments, paramType);
+    }
+}

--- a/src/test/java/com/jang/mcp/starter/util/ArgumentConverterTest.java
+++ b/src/test/java/com/jang/mcp/starter/util/ArgumentConverterTest.java
@@ -1,4 +1,4 @@
-package com.jang.mcp.starter.autoconfigure;
+package com.jang.mcp.starter.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jang.mcp.starter.annotation.McpParameter;
@@ -12,11 +12,9 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for the argument conversion logic used in McpAutoConfiguration.
- * Tests the ObjectMapper-based conversion behavior directly
- * since convertArguments() is a private method.
+ * Tests for ArgumentConverter.convert() — the production argument conversion logic.
  */
-class ConvertArgumentsTest {
+class ArgumentConverterTest {
 
     private ObjectMapper objectMapper;
 
@@ -30,19 +28,19 @@ class ConvertArgumentsTest {
         objectMapper = new ObjectMapper();
     }
 
-    // -- Parameterless tool behavior (null / Void) --
+    // -- Parameterless tool behavior --
 
     @Test
-    @DisplayName("Parameterless tools should receive null — null paramType")
+    @DisplayName("null paramType returns null")
     void nullParamTypeReturnsNull() {
-        Object result = convertArguments(Map.of("key", "value"), null, objectMapper);
+        Object result = ArgumentConverter.convert(Map.of("key", "value"), null, objectMapper);
         assertNull(result);
     }
 
     @Test
-    @DisplayName("Parameterless tools should receive null — Void paramType")
+    @DisplayName("Void paramType returns null")
     void voidParamTypeReturnsNull() {
-        Object result = convertArguments(Map.of("key", "value"), Void.class, objectMapper);
+        Object result = ArgumentConverter.convert(Map.of("key", "value"), Void.class, objectMapper);
         assertNull(result);
     }
 
@@ -55,7 +53,7 @@ class ConvertArgumentsTest {
         args.put("name", "Alice");
         args.put("count", 42);
 
-        Object result = convertArguments(args, TestParams.class, objectMapper);
+        Object result = ArgumentConverter.convert(args, TestParams.class, objectMapper);
 
         assertInstanceOf(TestParams.class, result);
         TestParams params = (TestParams) result;
@@ -69,7 +67,7 @@ class ConvertArgumentsTest {
         Map<String, Object> args = new HashMap<>();
         args.put("name", "Bob");
 
-        Object result = convertArguments(args, TestParams.class, objectMapper);
+        Object result = ArgumentConverter.convert(args, TestParams.class, objectMapper);
 
         assertInstanceOf(TestParams.class, result);
         TestParams params = (TestParams) result;
@@ -82,7 +80,7 @@ class ConvertArgumentsTest {
     void emptyArguments() {
         Map<String, Object> args = new HashMap<>();
 
-        Object result = convertArguments(args, TestParams.class, objectMapper);
+        Object result = ArgumentConverter.convert(args, TestParams.class, objectMapper);
 
         assertInstanceOf(TestParams.class, result);
         TestParams params = (TestParams) result;
@@ -96,7 +94,7 @@ class ConvertArgumentsTest {
     @DisplayName("null arguments with non-Void paramType throws IllegalArgumentException")
     void nullArgumentsThrows() {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
-                convertArguments(null, TestParams.class, objectMapper));
+                ArgumentConverter.convert(null, TestParams.class, objectMapper));
 
         assertTrue(ex.getMessage().contains("Missing arguments"));
         assertTrue(ex.getMessage().contains("TestParams"));
@@ -109,22 +107,7 @@ class ConvertArgumentsTest {
         args.put("name", "Alice");
         args.put("count", "not-a-number");
 
-        // ObjectMapper should throw when "not-a-number" can't be converted to Integer
         assertThrows(IllegalArgumentException.class, () ->
-                convertArguments(args, TestParams.class, objectMapper));
-    }
-
-    /**
-     * Mirror of McpAutoConfiguration.convertArguments() logic.
-     * Tested here to verify correctness without requiring full Spring context.
-     */
-    private Object convertArguments(Map<String, Object> arguments, Class<?> paramType, ObjectMapper mapper) {
-        if (paramType == null || paramType == Void.class) {
-            return null;
-        }
-        if (arguments == null) {
-            throw new IllegalArgumentException("Missing arguments for tool that expects parameters of type " + paramType.getSimpleName());
-        }
-        return mapper.convertValue(arguments, paramType);
+                ArgumentConverter.convert(args, TestParams.class, objectMapper));
     }
 }

--- a/src/test/java/com/jang/mcp/starter/util/McpSchemaGeneratorTest.java
+++ b/src/test/java/com/jang/mcp/starter/util/McpSchemaGeneratorTest.java
@@ -1,0 +1,133 @@
+package com.jang.mcp.starter.util;
+
+import com.jang.mcp.starter.annotation.McpParameter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class McpSchemaGeneratorTest {
+
+    // -- Test Records --
+
+    public record SimpleParams(
+            @McpParameter(description = "User name", required = true)
+            String name,
+            @McpParameter(description = "User age", required = false)
+            Integer age
+    ) {}
+
+    public record AllTypesParams(
+            @McpParameter(description = "a string") String text,
+            @McpParameter(description = "an int") int intVal,
+            @McpParameter(description = "an integer") Integer integerVal,
+            @McpParameter(description = "a long") long longVal,
+            @McpParameter(description = "a Long") Long longWrapperVal,
+            @McpParameter(description = "a float") float floatVal,
+            @McpParameter(description = "a double") double doubleVal,
+            @McpParameter(description = "a boolean") boolean boolVal,
+            @McpParameter(description = "a Boolean") Boolean boolWrapperVal
+    ) {}
+
+    public record NoAnnotationParams(
+            String username,
+            int count
+    ) {}
+
+    public record ListParam(
+            @McpParameter(description = "tags list")
+            List<String> tags
+    ) {}
+
+    // -- Tests --
+
+    @Test
+    @DisplayName("null parameterType returns empty schema")
+    void nullParameterType() {
+        Map<String, Object> schema = McpSchemaGenerator.generate(null);
+
+        assertEquals("object", schema.get("type"));
+        assertNotNull(schema.get("properties"));
+        assertTrue(((Map<?, ?>) schema.get("properties")).isEmpty());
+        assertNull(schema.get("required"));
+    }
+
+    @Test
+    @DisplayName("Record with @McpParameter generates correct properties and required list")
+    @SuppressWarnings("unchecked")
+    void simpleParamsSchema() {
+        Map<String, Object> schema = McpSchemaGenerator.generate(SimpleParams.class);
+
+        assertEquals("object", schema.get("type"));
+
+        Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+        assertNotNull(properties);
+        assertEquals(2, properties.size());
+
+        // name field
+        Map<String, Object> nameField = (Map<String, Object>) properties.get("name");
+        assertEquals("string", nameField.get("type"));
+        assertEquals("User name", nameField.get("description"));
+
+        // age field
+        Map<String, Object> ageField = (Map<String, Object>) properties.get("age");
+        assertEquals("integer", ageField.get("type"));
+        assertEquals("User age", ageField.get("description"));
+
+        // required - only "name" (age is required=false)
+        List<String> required = (List<String>) schema.get("required");
+        assertNotNull(required);
+        assertEquals(1, required.size());
+        assertTrue(required.contains("name"));
+        assertFalse(required.contains("age"));
+    }
+
+    @Test
+    @DisplayName("All Java types are correctly mapped to JSON Schema types")
+    @SuppressWarnings("unchecked")
+    void allTypesMapping() {
+        Map<String, Object> schema = McpSchemaGenerator.generate(AllTypesParams.class);
+        Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+
+        assertEquals("string", ((Map<String, Object>) properties.get("text")).get("type"));
+        assertEquals("integer", ((Map<String, Object>) properties.get("intVal")).get("type"));
+        assertEquals("integer", ((Map<String, Object>) properties.get("integerVal")).get("type"));
+        assertEquals("integer", ((Map<String, Object>) properties.get("longVal")).get("type"));
+        assertEquals("integer", ((Map<String, Object>) properties.get("longWrapperVal")).get("type"));
+        assertEquals("number", ((Map<String, Object>) properties.get("floatVal")).get("type"));
+        assertEquals("number", ((Map<String, Object>) properties.get("doubleVal")).get("type"));
+        assertEquals("boolean", ((Map<String, Object>) properties.get("boolVal")).get("type"));
+        assertEquals("boolean", ((Map<String, Object>) properties.get("boolWrapperVal")).get("type"));
+    }
+
+    @Test
+    @DisplayName("Fields without @McpParameter are still included but without description")
+    @SuppressWarnings("unchecked")
+    void noAnnotationFields() {
+        Map<String, Object> schema = McpSchemaGenerator.generate(NoAnnotationParams.class);
+        Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+
+        assertEquals(2, properties.size());
+
+        Map<String, Object> usernameField = (Map<String, Object>) properties.get("username");
+        assertEquals("string", usernameField.get("type"));
+        assertNull(usernameField.get("description"));
+
+        // No required list since no @McpParameter annotation
+        assertNull(schema.get("required"));
+    }
+
+    @Test
+    @DisplayName("List type fields are mapped to 'array'")
+    @SuppressWarnings("unchecked")
+    void listTypeMapping() {
+        Map<String, Object> schema = McpSchemaGenerator.generate(ListParam.class);
+        Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+
+        Map<String, Object> tagsField = (Map<String, Object>) properties.get("tags");
+        assertEquals("array", tagsField.get("type"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit tests for the library's core components, covering JSON Schema generation and argument conversion logic.

Closes #4

## Tests Added

### McpSchemaGeneratorTest (6 tests)
- null parameterType returns empty schema
- Record with @McpParameter generates correct properties and required list
- All Java types correctly mapped to JSON Schema types
- Fields without @McpParameter included without description
- List type mapped to 'array'

### ConvertArgumentsTest (7 tests)
- null / Void paramType returns null
- Valid arguments converted to typed object
- Partial arguments convert with null for missing fields
- Empty map converts to object with all null fields
- null arguments with non-Void paramType throws IllegalArgumentException
- Invalid type throws conversion exception
