### PR TITLE
chore: upgrade MCP SDK from 1.1.0 to 1.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 ext {
-    mcpSdkVersion = '1.1.0'
+    mcpSdkVersion = '1.1.1'
     // Minimum compatible Spring Boot version for annotation processors only (build-time)
     springBootVersion = '3.3.0'
 }


### PR DESCRIPTION
## Summary

Upgrades MCP Java SDK from 1.1.0 to 1.1.1 (patch release).

Relates to #1

## Changes

- `build.gradle`: `mcpSdkVersion` 1.1.0 -> 1.1.1

## What's in SDK 1.1.1

- Removed `Access-Control-Allow-Origin` header from server transports (CORS fix)

## Note on Protocol Version

Tested with protocol version `2025-11-25` — SDK 1.1.1 includes `ProtocolVersions` constants for newer protocols but the server still negotiates `2024-11-05` only. Full protocol upgrade depends on SDK upstream changes. Issue #1 remains open.
